### PR TITLE
Try to DROP dms_user before CREATE USER

### DIFF
--- a/PostgreSQL/sampledb/v1/user/create-user.sql
+++ b/PostgreSQL/sampledb/v1/user/create-user.sql
@@ -1,4 +1,5 @@
-create user dms_user with password 'dms_user';
+DROP USER IF EXISTS dms_user;
+CREATE USER dms_user WITH PASSWORD 'dms_user';
 GRANT ALL PRIVILEGES ON                  SCHEMA dms_sample TO dms_user;
 GRANT ALL PRIVILEGES ON ALL TABLES    IN SCHEMA dms_sample TO dms_user;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA dms_sample TO dms_user;


### PR DESCRIPTION
Try to DROP dms_user before CREATE USER. This is required, if you re-run the script twice on any cluster (with a --single-transaction enabled). Without this DROP USER, it'd fail saying User already exists.