### PR TITLE
Optimize SellTickets call by merging it as a single SQL within the Ca…

### DIFF
--- a/PostgreSQL/sampledb/v1/README.md
+++ b/PostgreSQL/sampledb/v1/README.md
@@ -80,9 +80,8 @@ This will generate 100 "transfer" transactions. Tickets are transfered as a grou
 * **loadmlbteams:** Loads the Major League Baseball team data from the base data
 * **loadnflplayers:** Loads the NFL players from the base data
 * **loadnflteams:** Loads the NFL teams from the base data
-* **selltickets:** Sells ticket(s) to a person
 * **transferticket:** Transfers ticket(s) from one person to another
-* **generateticketactivity:** Repeatedly sells a random number of tickets (1-6) to a random person (calls sellTickets)
+* **generateticketactivity:** Repeatedly sells a random number of tickets (1-6) to a random person
 * **generatetransferactivity:** Repeatedly transfers tickets from one person to another. 80% are transferred as a group, 20% as singlets (calls transferTicket)
 
 ### TABLES

--- a/PostgreSQL/sampledb/v1/install-postgresql.sql
+++ b/PostgreSQL/sampledb/v1/install-postgresql.sql
@@ -72,7 +72,6 @@ select generatesporttickets('baseball');
 
 -- Sell tickets and generating ticket activities
 select null as "Creating functions to sell and transfer tickets";
-\i ./schema/functions/selltickets.sql
 \i ./schema/functions/generateticketactivity.sql
 -- generating some initial ticket purchases
 select generateticketactivity(5000);

--- a/PostgreSQL/sampledb/v1/schema/functions/generateticketactivity.sql
+++ b/PostgreSQL/sampledb/v1/schema/functions/generateticketactivity.sql
@@ -23,7 +23,41 @@ BEGIN
 	rand_person_id := floor(random()*(max_person_id-min_person_id+min_person_id))+min_person_id;
 	rand_event_id := floor(random()*(max_event_id-min_event_id+min_event_id))+min_event_id;
 	tick_quantity := floor(random()*(10000-2000+2000))+2000;
-	PERFORM dms_sample.selltickets(rand_person_id, rand_event_id, tick_quantity);
+      
+    WITH ticket_list AS (
+      SELECT
+        id AS var_v_ticket_id, 
+        seat_level AS var_v_seat_level,
+        seat_section AS var_v_seat_section,
+        seat_row AS var_v_seat_row
+      FROM dms_sample.sporting_event_ticket
+      WHERE sporting_event_id = rand_event_id
+      ORDER BY seat_level NULLS FIRST, 
+        LOWER(seat_section) NULLS FIRST, 
+        LOWER(seat_row) NULLS FIRST
+      LIMIT tick_quantity
+    ),
+     ticket_holder_list AS (
+      UPDATE dms_sample.sporting_event_ticket
+        SET ticketholder_id = rand_person_id
+      FROM ticket_list
+      WHERE id = var_v_ticket_id
+      RETURNING id,
+        ticketholder_id,
+        ticket_price
+    )
+    INSERT INTO dms_sample.ticket_purchase_hist (
+      sporting_event_ticket_id, 
+      purchased_by_id, 
+      transaction_date_time, 
+      purchase_price)
+    SELECT
+      id,
+      ticketholder_id, 
+      clock_timestamp()::TIMESTAMP, 
+      ticket_price
+    FROM ticket_holder_list;
+
 	var_current_txn := (var_current_txn + 1)::INT;
 	END LOOP;
 END;


### PR DESCRIPTION
Optimize SellTickets call by merging it as a single SQL within the Caller SQL. The SQL earlier was taking more than 30+ minutes just for GenerateTicketActivity. Now generally finishes in less than a minute.